### PR TITLE
bugfix: undefined is not the same as null in composer.let

### DIFF
--- a/addSubscription.js
+++ b/addSubscription.js
@@ -32,7 +32,7 @@ if (cloudantBinding === undefined) {
   process.exit(-1)
 }
 
-composer.let({ db: dbname, sc: slackConfig, userID: undefined, name: undefined },
+composer.let({ db: dbname, sc: slackConfig, userID: null, name: null },
   composer.sequence(
     `/whisk.system/utils/echo`,
     p => { name = p.text; docId = p.text.toUpperCase(); userID = p.user_id },

--- a/travis2slack.js
+++ b/travis2slack.js
@@ -52,7 +52,7 @@ function getAuthorMapComposition() {
   }
 }
 
-composer.let({ prDetails: undefined, authorSlackInfo: undefined },
+composer.let({ prDetails: null, authorSlackInfo: null },
   composer.sequence(
     `/whisk.system/utils/echo`,
     `${prefix}/extract`,


### PR DESCRIPTION
Avoid interesting JS/JSON trap.  Declaring a variable in a
composer.let with an undefined initial value results in it not
actually being declared in the composition's environment.  Olivier
will document this behavior in Composer documentation.  The
compositions may still mostly work by accident, especially when not
under load because the unscoped variable was instead being stored in
the global JS environment.  If the initialized write and later read(s)
of the variable happened to be executed in the same container without
an intervening write by another composition, then the computation still
"worked" by accessing the global JS state (even though that was not
the intended semantics).