### PR TITLE
eliminate leading whitespace from author names

### DIFF
--- a/travis2slack.js
+++ b/travis2slack.js
@@ -46,7 +46,7 @@ function getAuthorMapComposition() {
   } else {
     return composer.let({ db: dbname },
       composer.sequence(
-        p => ({ dbname: db, docid: p.author.toUpperCase() }),
+        p => ({ dbname: db, docid: p.author.trim().toUpperCase() }),
         composer.try(`${cloudantBinding}/read-document`, _ => ({}))
       ))
   }


### PR DESCRIPTION
1. Trim leading whitespace from author name on both subscribe and lookup.
2. Give usage message for subscribe command with empty name
3. Add comments to addSubscription and store response message in
   environment instead of passing it implicitly along all paths.