### PR TITLE
Add support for matrix builds

### DIFF
--- a/analyze-log.py
+++ b/analyze-log.py
@@ -21,20 +21,21 @@ import sys
 from contextlib import closing
 
 def main(args):
-    log_url = args.get("log_url")
+    log_urls = args.get("log_urls")
 
-    if not log_url:
-        return { "error": "Expected log_url to be specified." }
+    if not log_urls:
+        return { "error": "Expected log_urls to be specified." }
 
     failed_tests = {}
 
-    with closing(requests.get(log_url, stream=True)) as r:
-        for line in r.iter_lines():
-            m = re.match("""^([^>]*) > (.*) FAILED$""", line.strip())
-            if m is not None:
-                suite = m.group(1)
-                test = m.group(2)
-                failed_tests.setdefault(suite, []).append(test)
+    for log_url in log_urls:
+        with closing(requests.get(log_url, stream=True)) as r:
+            for line in r.iter_lines():
+                m = re.match("""^([^>]*) > (.*) FAILED$""", line.strip())
+                if m is not None:
+                    suite = m.group(1)
+                    test = m.group(2)
+                    failed_tests.setdefault(suite, []).append(test)
 
     return { 
         "log_url": log_url,
@@ -43,5 +44,5 @@ def main(args):
 
 # For local testing.
 if __name__ == "__main__":
-    result = main({ "log_url": sys.argv[1] })
+    result = main({ "log_urls": sys.argv[1] })
     print json.dumps(result, indent=2)

--- a/do.sh
+++ b/do.sh
@@ -73,8 +73,9 @@ function teardown() {
 }
 
 function test() {
-  # Edit the author map to provide a valid Slack id for "Jane Doe" for ths sample formdata to reach you on Slack.
-  $WSK action invoke "${PREFIX}/receive.travis.webhook" --param-file "sample-formdata.json"
+  # Edit the author map to provide a valid Slack id for "Jane Doe" for these examples to reach you on Slack.
+  $WSK action invoke "${PREFIX}/receive.travis.webhook" --param-file "test1.json"
+  $WSK action invoke "${PREFIX}/receive.travis.webhook" --param-file "test2.json"
 }
 
 function usage() {

--- a/fetch-job-id.js
+++ b/fetch-job-id.js
@@ -19,7 +19,7 @@
  *           { "author" : string, 
  *             "build_id": numeric_string,
  *             "status": "success" | "error" | "failure" }
- * @return the record augmented with { "job_id" : numeric_string }
+ * @return the record augmented with { "job_ids" : [numeric_string] }
  */
 function main(args) {
     const build_id = args["build_id"]
@@ -45,8 +45,8 @@ function main(args) {
             } else {
                 // forwards the incoming arguments...
                 let result = args;
-                // ... after augmenting with job id
-                result["job_id"] = (body["jobs"][0]["id"]).toString();
+                // ... after augmenting with array of job ids
+                result["job_ids"] = body["jobs"].map(j => j["id"])
                 resolve(result);
             }
         });

--- a/test1.json
+++ b/test1.json
@@ -1,0 +1,2 @@
+{"payload": "{\"author_name\": \"Jane Doe\",\"branch\": \"master\",\"build_url\": \"https://travis-ci.org/apache/incubator-openwhisk/builds/198265062\",\"compare_url\": \"https://github.com/apache/incubator-openwhisk/pull/1812\",\"pull_request_number\": \"1812\", \"state\": \"passed\"}"
+}

--- a/test2.json
+++ b/test2.json
@@ -1,0 +1,2 @@
+{"payload": "{\"author_name\": \"Jane Doe\",\"branch\": \"master\",\"build_url\": \"https://travis-ci.org/apache/incubator-openwhisk/builds/421337234\",\"compare_url\": \"https://github.com/apache/incubator-openwhisk/pull/3976\",\"pull_request_number\": \"3976\", \"state\": \"failed\"}"
+}


### PR DESCRIPTION
Enhance job/log extraction functions to handle matrix jobs, where
there are multiple entires in the jobs[] of the primary job.
Previously, we only processed the first entry in the jobs[] which
resulted in not finding/listing individual test failures in matrix
jobs.